### PR TITLE
URL Cleanup

### DIFF
--- a/riff.nuspec
+++ b/riff.nuspec
@@ -10,7 +10,7 @@
     <!-- == SOFTWARE SPECIFIC SECTION == -->
     <title>riff is for functions</title>
     <authors>riff team</authors>
-    <projectUrl>http://projectriff.io/</projectUrl>
+    <projectUrl>https://projectriff.io/</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/projectriff/riff@master/logo.png</iconUrl>
     <licenseUrl>https://github.com/projectriff/riff/blob/master/LICENSE</licenseUrl>
     <packageSourceUrl>https://github.com/projectriff/chocolatey</packageSourceUrl>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd (404) with 1 occurrences could not be migrated:  
   ([https](https://schemas.microsoft.com/packaging/2015/06/nuspec.xsd) result AnnotatedConnectException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://projectriff.io/ with 1 occurrences migrated to:  
  https://projectriff.io/ ([https](https://projectriff.io/) result 200).